### PR TITLE
Remove "--harmony-tailcalls" flag from main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node --harmony-tailcalls
-
 var fs = require("fs");
 var path = require("path");
 var L = require("./lambda-calculus.js");
@@ -14,11 +12,11 @@ try {
 } catch (e) {
   console.log("Absal evaluates λ-terms optimally (no oracle).");
   console.log("Usage:");
-  console.log("  absal [--stats] [--bruijn] fileName[.lam]"); 
-  console.log("Syntax:"); 
-  console.log("  #arg body      : lambda expression"); 
-  console.log("  /fn arg        : applies fn to arg"); 
-  console.log("  @name val expr : let name be val in expr"); 
+  console.log("  absal [--stats] [--bruijn] fileName[.lam]");
+  console.log("Syntax:");
+  console.log("  #arg body      : lambda expression");
+  console.log("  /fn arg        : applies fn to arg");
+  console.log("  @name val expr : let name be val in expr");
   console.log("Example:");
   console.log("  @four #f #x /f /f /f /f x");
   console.log("  /four four");


### PR DESCRIPTION
The "--harmony-tailcalls" flag on main.js was causing execution error "/usr/bin/env: ‘node --harmony-tailcalls’: No such file or directory". This is a small fix to the problem.