### PR TITLE
Add support for \r\n and fix List.fold error.

### DIFF
--- a/lib/main.lam
+++ b/lib/main.lam
@@ -164,7 +164,7 @@
 
 @List.fold /Y #R #xs #con #nil
   //xs
-    #x #xs //con x /R xs
+    #x #xs //con x ///R xs con nil
     nil
 
 @List.toCList /Y #R #xs
@@ -496,4 +496,3 @@
 @I Bool.true
 @K0 #t ////////////////////////////////////////////////////////////////t O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I O I
 @KS #t /////////////////////////t K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0 K0
-/keccakf KS

--- a/src/lambda-calculus.js
+++ b/src/lambda-calculus.js
@@ -8,7 +8,7 @@ const fromString = src => {
   var i = 0;
   var parseString = (name) => {
     var str = "";
-    while (src[i] && (name ? !/[ \n]/.test(src[i]) : src[i] !== ")")) {
+    while (src[i] && (name ? !/[\r|\n| ]/.test(src[i]) : src[i] !== ")")) {
       str += src[i++];
     }
     return str;
@@ -19,8 +19,7 @@ const fromString = src => {
   var parseTerm = (ctx, nofv) => {
     switch (src[i++]) {
       case ' ':
-      case ' ':
-        return parseTerm(ctx, nofv);
+      case '\r':
       case '\n':
         return parseTerm(ctx, nofv);
       case '#':


### PR DESCRIPTION
Also the current implementation of `List.map` is unfortunate, because evaluating `//List.map /CNat.add 1 xs` will loop forever.

On the other hand 
```haskell
@List.map #f #xs
  ///List.fold xs #x /List.con /f x List.nil

//List.map /CNat.add 1 xs
```
will terminate...