### PR TITLE
Name refactoring, duplication rule, --dump.

### DIFF
--- a/src/abstract-combinators.js
+++ b/src/abstract-combinators.js
@@ -110,6 +110,18 @@ function rewrite(net, A, B) {
   net.stats.rules += 1;
 }
 
+function show(net) {
+  console.log(net.stats);
+  for (var i=0; i < net.nodes.length;i+=4) {
+    if (net.reuse.some(x => x === i>>2)) {
+      console.log(i>>2);
+      continue;
+    }
+    [a,b,c,d] = net.nodes.slice(i, i+3)
+    console.log(i>>2, `${a>>2}:${a&3} ${b>>2}:${b&3} ${c>>2}:${c&3} ${d>>2}:${d&3}`);
+  }
+}
+
 module.exports = {
   port,
   node,
@@ -122,5 +134,6 @@ module.exports = {
   setMeta,
   link,
   reduce,
-  rewrite
+  rewrite,
+  show
 };

--- a/src/abstract-combinators.js
+++ b/src/abstract-combinators.js
@@ -73,36 +73,40 @@ function reduce(net) {
   return net;
 }
 
-function rewrite(net, x, y) {
-  if (kind(net,x) === kind(net,y)) {
+function rewrite(net, A, B) {
+  if (kind(net,A) === kind(net,B)) {
     //  1          2            1   2
     //   \        /              \ / 
     //     A == B       -->       X  
     //   /        \              / \ 
     //  2          1            2   1
-    link(net, enterPort(net, port(x, 1)),  enterPort(net, port(y, 1)));
-    link(net, enterPort(net, port(x, 2)),  enterPort(net, port(y, 2)));
-    net.stats.betas += kind(net, x) === 1 ? 1 : 0;
+    link(net, enterPort(net, port(A, 1)),  enterPort(net, port(B, 1)));
+    link(net, enterPort(net, port(A, 2)),  enterPort(net, port(B, 2)));
+    net.stats.betas += kind(net, A) === 1 ? 1 : 0;
     net.stats.annis += 1;
+    net.reuse.push(A, B);
   } else {
     //  1          2       1 = B --- A = 2
     //   \        /              \ /   
     //     A == B     -->         X    
     //   /        \              / \  
     //  2          1       2 = B --- A = 1 
-    var x1 = newNode(net, kind(net, x)), x2 = newNode(net, kind(net, x));
-    var y1 = newNode(net, kind(net, y)), y2 = newNode(net, kind(net, y));
-    link(net, enterPort(net, port(y1, 0)), enterPort(net, port(x, 1)));
-    link(net, enterPort(net, port(y2, 0)), enterPort(net, port(x, 2)));
-    link(net, enterPort(net, port(x1, 0)), enterPort(net, port(y, 1)));
-    link(net, enterPort(net, port(x2, 0)), enterPort(net, port(y, 2)));
-    link(net, enterPort(net, port(x1, 1)), enterPort(net, port(y1, 1)));
-    link(net, enterPort(net, port(x1, 2)), enterPort(net, port(y2, 1)));
-    link(net, enterPort(net, port(x2, 1)), enterPort(net, port(y1, 2)));
-    link(net, enterPort(net, port(x2, 2)), enterPort(net, port(y2, 2)));
+    var a = newNode(net, kind(net, A));
+    var b = newNode(net, kind(net, B));
+    
+    link(net, port(b, 0), enterPort(net, port(A, 1)));
+    link(net, port(B, 0), enterPort(net, port(A, 2)));
+    link(net, port(a, 0), enterPort(net, port(B, 1)));
+    link(net, port(A, 0), enterPort(net, port(B, 2)));
+    link(net, port(a, 1), port(b, 1));
+    link(net, port(a, 2), port(B, 1));
+    link(net, port(A, 1), port(b, 2));
+    link(net, port(A, 2), port(B, 2));
+
+    setMeta(net, A, 0);
+    setMeta(net, B, 0);
     net.stats.dupls += 1;
   }
-  net.reuse.push(x, y);
   net.stats.rules += 1;
 }
 

--- a/src/abstract-combinators.js
+++ b/src/abstract-combinators.js
@@ -19,11 +19,11 @@ function newNet(nodes) {
 }
 
 function newNode(net, kind) {
-  var node = net.reuse.pop() || (net.nodes.length / 4);
+  var node = net.reuse.pop() || (net.nodes.length >> 2);
   net.nodes[node * 4 + 0] = node * 4 + 0;
   net.nodes[node * 4 + 1] = node * 4 + 1;
   net.nodes[node * 4 + 2] = node * 4 + 2;
-  net.nodes[node * 4 + 3] = kind << 2;
+  net.nodes[node * 4 + 3] = kind * 4;
   return node;
 }
 
@@ -117,7 +117,7 @@ function show(net) {
       console.log(i>>2);
       continue;
     }
-    [a,b,c,d] = net.nodes.slice(i, i+3)
+    [a,b,c,d] = net.nodes.slice(i, i+4)
     console.log(i>>2, `${a>>2}:${a&3} ${b>>2}:${b&3} ${c>>2}:${c&3} ${d>>2}:${d&3}`);
   }
 }

--- a/src/lambda-calculus.js
+++ b/src/lambda-calculus.js
@@ -154,7 +154,7 @@ const fromNet = net => {
 };
 
 const reduce = (src, returnStats, bruijn, dump) => {
-  const reduced = I.reduce(toNet(fromString(src)), dump);
+  const reduced = I.reduce(toNet(fromString(src)));
   if(dump) {
     I.show(reduced);
   }

--- a/src/lambda-calculus.js
+++ b/src/lambda-calculus.js
@@ -99,7 +99,7 @@ const toNet = term => {
         return I.port(app,2);
       case "Var":
         var lam = scope[term.idx];
-        if (I.getNodeKind(net,I.getPortNode(I.enterPort(net,I.port(lam,1)))) === 0) {
+        if (I.kind(net,I.node(I.enterPort(net,I.port(lam,1)))) === 0) {
           return I.port(lam,1);
         } else {
           var dup = I.newNode(net, ++kind);
@@ -118,9 +118,9 @@ const fromNet = net => {
   var nodeDepth = {};
   return (function go(next, exit, depth){
     var prev = I.enterPort(net, next);
-    var prevPort = I.getPortSlot(prev);
-    var prevNode = I.getPortNode(prev);
-    if (I.getNodeKind(net, prevNode) === 1) {
+    var prevPort = I.slot(prev);
+    var prevNode = I.node(prev);
+    if (I.kind(net, prevNode) === 1) {
       switch (prevPort) {
         case 0:
           nodeDepth[prevNode] = depth;

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ try {
   var args = [].slice.call(process.argv, 2);
   var stats = args.indexOf("-s") !== -1 || args.indexOf("--stats") !== -1;
   var bruijn = args.indexOf("-b") !== -1 || args.indexOf("--bruijn") !== -1;
+  var dump = args.indexOf("-d") !== -1 || args.indexOf("--dump") !== -1;
   var file = args[args.length - 1];
   var base = fs.readFileSync(path.join(__dirname, "..", "lib", "base.lam"), "utf8");
   var code = fs.readFileSync("./" + (file.indexOf(".") === -1 ? file + ".lam" : file), "utf8");
@@ -32,7 +33,7 @@ try {
 }
 
 var start = Date.now();
-var result = L.reduce(`${base} ${code}`, 1, bruijn);
+var result = L.reduce(`${base} ${code}`, 1, bruijn, dump);
 
 console.log(result.term);
 if (stats) {


### PR DESCRIPTION
This pull request has two parts:

First I polished the function names a little bit, so the code is easier to read (IMHO putting `get` or `function argument names` inside function name is antipattern). Although descriptive function names can lead to better readability, not being concise will lead to the opposite.

Secondly, I cleaned up the duplication rule and reused the `A` and `B` nodes, so there is only one allocation instead of two. Running `main.lam` is almost twice as fast with this change!